### PR TITLE
Use a bound composer constraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "minimum-stability": "dev",
     "require": {
         "php": ">=5.3.3",
-     	"doctrine/dbal": ">=2.3.4" 
+     	"doctrine/dbal": "^2.3.4" 
     },
     "require-dev": {
     },


### PR DESCRIPTION
Your package should not advocate compatibility with future major versions of DBAL
